### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/me/geed/util/Constant.java
+++ b/app/src/main/java/me/geed/util/Constant.java
@@ -3,7 +3,12 @@ package me.geed.util;
 /**
  * Created by Andy on 2016/3/21.
  */
-public class Constant {
+public final class Constant {
 
     public static final String LOCK_SCREEN_ACTION = "android.intent.lockscreen";
+
+    private Constant() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
 }

--- a/app/src/main/java/me/geed/util/TimeUtil.java
+++ b/app/src/main/java/me/geed/util/TimeUtil.java
@@ -6,7 +6,12 @@ import java.util.Date;
 /**
  * Created by Andy on 2016/3/21.
  */
-public class TimeUtil {
+public final class TimeUtil {
+    
+    private TimeUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     /**
      * @return "HH:mm:ss"
      */

--- a/app/src/main/java/me/geed/util/Validator.java
+++ b/app/src/main/java/me/geed/util/Validator.java
@@ -3,7 +3,12 @@ package me.geed.util;
 /**
  * Created by Andy on 2016/3/22.
  */
-public class Validator {
+public final class Validator {
+
+    private Validator() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     /**
      * check whether be empty/null or not
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
